### PR TITLE
fix(AHWR-778): Add resiliency against DB issues

### DIFF
--- a/app/constants/index.js
+++ b/app/constants/index.js
@@ -4,5 +4,6 @@ export const MESSAGE_RESULT_MAP = {
   unknown: 'UNKNOWN',
   unsent: 'UNSENT',
   sent: 'SENT',
-  failed: 'FAILED'
+  failed: 'FAILED',
+  requested: 'REQUESTED'
 }

--- a/app/logger.js
+++ b/app/logger.js
@@ -40,7 +40,7 @@ const options = {
   formatters: {
     level: (level) => ({ level })
   },
-  ignorePaths: ['healthy', 'healthz'],
+  ignorePaths: ['/healthy', '/healthz'],
   serializers: {
     req,
     res,

--- a/app/repositories/message-log-repository.js
+++ b/app/repositories/message-log-repository.js
@@ -4,3 +4,9 @@ export const set = async (data) => {
   const { models } = dataModeller
   await models.messageLog.create(data)
 }
+
+export const update = async (id, data) => {
+  const { models } = dataModeller
+  return models.messageLog.update(data,
+    { where: { id } })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-sfd-messaging-proxy",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-sfd-messaging-proxy",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@azure/identity": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-sfd-messaging-proxy",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Proxies messages through to Single Frontdoor (SFD) service",
   "homepage": "https://github.com/DEFRA/ffc-ahwr-sfd-messaging-proxy",
   "main": "app/index.js",


### PR DESCRIPTION
In the event we can't contact DB, fail **before** sending to SFD, so we can then replay the message and redo the entire transaction, instead of having to unpick a half completed transaction.

Change the status flow slightly to fit with the above.

Add details to Db first with status of UNKNOWN.
Attempt to send to SFD, and update status to either of REQUESTED if we sent outbound successfully or UNSENT if it was not sent out.

Also add the outbound message Id to logging context once it's been generated.

Also fixed the health endpoints no being properly ignored by logging.